### PR TITLE
feat(rpc): add getSlot, getBlockHeight, getMinimumBalanceForRentExemption

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -164,6 +164,49 @@ impl RpcClient {
             .await?;
         Ok(resp.value)
     }
+
+    /// `getSlot` - current slot the RPC node is on. Useful alongside
+    /// `confirmTransaction` for freshness checks and for telling a user how
+    /// far behind tip a connection is.
+    pub async fn get_slot(&self) -> Result<u64> {
+        self.get_slot_with_commitment(CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_slot_with_commitment(&self, commitment: CommitmentConfig) -> Result<u64> {
+        self.call(
+            "getSlot",
+            json!([{ "commitment": commitment.commitment.to_string() }]),
+        )
+        .await
+    }
+
+    /// `getBlockHeight` - current block height (distinct from slot; skipped
+    /// slots aren't counted). Often paired with `getSlot` to diagnose fork
+    /// conditions or warn the user when skip rate is high.
+    pub async fn get_block_height(&self) -> Result<u64> {
+        self.get_block_height_with_commitment(CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_block_height_with_commitment(
+        &self,
+        commitment: CommitmentConfig,
+    ) -> Result<u64> {
+        self.call(
+            "getBlockHeight",
+            json!([{ "commitment": commitment.commitment.to_string() }]),
+        )
+        .await
+    }
+
+    /// `getMinimumBalanceForRentExemption` - lamports required to make an
+    /// account of `data_len` bytes rent-exempt. Needed before creating any
+    /// on-chain account.
+    pub async fn get_minimum_balance_for_rent_exemption(&self, data_len: u64) -> Result<u64> {
+        self.call("getMinimumBalanceForRentExemption", json!([data_len]))
+            .await
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
Adds three low-risk u64-returning methods to `RpcClient` from the "Easy pickings" list in issue #5: `get_slot`, `get_block_height`, and `get_minimum_balance_for_rent_exemption`.

## Why this matters
Issue #5 points at `src/rpc.rs` and notes RpcClient currently has three methods (`get_latest_blockhash`, `get_balance`, `send_transaction_b64`), while a real consumer hits several more every session. Keeping this PR narrow to three unambiguous methods:

- **get_slot** - current slot; useful alongside `confirmTransaction` for freshness checks
- **get_block_height** - distinct from slot (skipped slots don't count); useful for diagnosing forks
- **get_minimum_balance_for_rent_exemption** - lamports for a rent-exempt account of N bytes, required before creating any on-chain account

I left out the more-opinionated methods (`getAccountInfo`, `getMultipleAccounts`, `getTokenAccountsByOwner`, `getProgramAccounts`, etc.) because they each need a response struct and encoding decision - better as a follow-up PR per method rather than a megapatch that has to be rewritten on review.

## Changes
- `src/rpc.rs`: three new methods on `RpcClient`, each matching the existing `get_balance` pattern - a commitment-defaulted convenience wrapper plus an explicit `*_with_commitment` variant that takes `CommitmentConfig`. `get_minimum_balance_for_rent_exemption` doesn't need a commitment variant (per Solana JSON-RPC spec it doesn't take one). Uses the private `call()` helper.

## Testing
```
$ cargo check --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s)
$ cargo clippy --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

The new methods are typed against the same primitives (`u64`, `CommitmentConfig`) and call helper used by `get_balance`, so they compile against the existing `serde_json::from_str` path. No runtime test harness exists for browser-only `gloo-net` calls.

Partially fixes #5 (three items from the checklist). The rest can follow in focused PRs.

This contribution was developed with AI assistance (Claude Code).
