### PR TITLE
feat(rpc): add getAccountInfo, getMultipleAccounts, requestAirdrop

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,11 +3,15 @@
 //! We only implement the methods a client app needs to build, submit, and
 //! confirm transactions — no tokio, no `solana-client`. Extend as needed.
 
+use std::str::FromStr;
+
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;
+use solana_pubkey::Pubkey;
 use wasm_bindgen::JsValue;
 
 use crate::error::{Error, Result};
@@ -207,6 +211,135 @@ impl RpcClient {
         self.call("getMinimumBalanceForRentExemption", json!([data_len]))
             .await
     }
+
+    /// `getAccountInfo` - read arbitrary account data. Returns `None` if the
+    /// account does not exist on-chain.
+    ///
+    /// Uses `confirmed` commitment by default; for finalized reads call
+    /// `get_account_info_with_commitment` and pass `CommitmentConfig::finalized()`.
+    pub async fn get_account_info(&self, address: &str) -> Result<Option<AccountInfo>> {
+        self.get_account_info_with_commitment(address, CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_account_info_with_commitment(
+        &self,
+        address: &str,
+        commitment: CommitmentConfig,
+    ) -> Result<Option<AccountInfo>> {
+        #[derive(Deserialize)]
+        struct Resp {
+            value: Option<AccountInfoRaw>,
+        }
+        let resp: Resp = self
+            .call(
+                "getAccountInfo",
+                json!([
+                    address,
+                    {
+                        "commitment": commitment.commitment.to_string(),
+                        "encoding": "base64",
+                    }
+                ]),
+            )
+            .await?;
+        match resp.value {
+            None => Ok(None),
+            Some(raw) => Ok(Some(account_info_from_raw(raw)?)),
+        }
+    }
+
+    /// `getMultipleAccounts` - batch variant of `getAccountInfo`. Saves
+    /// round-trips when fetching N known account addresses. The returned
+    /// vector is parallel to `addresses` and uses `None` for any address
+    /// that does not exist on-chain.
+    pub async fn get_multiple_accounts(
+        &self,
+        addresses: &[&str],
+    ) -> Result<Vec<Option<AccountInfo>>> {
+        self.get_multiple_accounts_with_commitment(addresses, CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_multiple_accounts_with_commitment(
+        &self,
+        addresses: &[&str],
+        commitment: CommitmentConfig,
+    ) -> Result<Vec<Option<AccountInfo>>> {
+        #[derive(Deserialize)]
+        struct Resp {
+            value: Vec<Option<AccountInfoRaw>>,
+        }
+        let resp: Resp = self
+            .call(
+                "getMultipleAccounts",
+                json!([
+                    addresses,
+                    {
+                        "commitment": commitment.commitment.to_string(),
+                        "encoding": "base64",
+                    }
+                ]),
+            )
+            .await?;
+        resp.value
+            .into_iter()
+            .map(|opt| match opt {
+                None => Ok(None),
+                Some(raw) => Ok(Some(account_info_from_raw(raw)?)),
+            })
+            .collect()
+    }
+
+    /// `requestAirdrop` - dev/test convenience: ask the cluster to credit
+    /// `lamports` to `address`. Returns the resulting transaction signature.
+    /// Mainnet rejects this call; this is for `devnet` / `testnet` /
+    /// `solana-test-validator` only.
+    pub async fn request_airdrop(&self, address: &str, lamports: u64) -> Result<String> {
+        self.call("requestAirdrop", json!([address, lamports])).await
+    }
+}
+
+/// Decoded account state returned by `getAccountInfo` / `getMultipleAccounts`.
+#[derive(Clone, Debug)]
+pub struct AccountInfo {
+    /// Raw account data, base64-decoded into bytes.
+    pub data: Vec<u8>,
+    /// Owning program.
+    pub owner: Pubkey,
+    /// Account balance in lamports.
+    pub lamports: u64,
+    /// True if the account is an executable program.
+    pub executable: bool,
+    /// Epoch in which the account next owes rent.
+    pub rent_epoch: u64,
+}
+
+#[derive(Deserialize)]
+struct AccountInfoRaw {
+    /// Tuple of `[base64_string, "base64"]` when encoding=base64.
+    data: (String, String),
+    owner: String,
+    lamports: u64,
+    executable: bool,
+    #[serde(default)]
+    rent_epoch: u64,
+}
+
+fn account_info_from_raw(raw: AccountInfoRaw) -> Result<AccountInfo> {
+    let (data_b64, _encoding) = raw.data;
+    let data = BASE64_STANDARD
+        .decode(data_b64.as_bytes())
+        .map_err(|e| Error::Decode(format!("account data: {e}")))?;
+    let owner = Pubkey::from_str(&raw.owner)
+        .map_err(|e| Error::Decode(format!("account owner: {e}")))?;
+    Ok(AccountInfo {
+        data,
+        owner,
+        lamports: raw.lamports,
+        executable: raw.executable,
+        rent_epoch: raw.rent_epoch,
+    })
 }
 
 #[derive(Deserialize)]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -322,7 +322,8 @@ struct AccountInfoRaw {
     owner: String,
     lamports: u64,
     executable: bool,
-    #[serde(default)]
+    /// Solana wire format uses camelCase; the field arrives as `rentEpoch`.
+    #[serde(rename = "rentEpoch", default)]
     rent_epoch: u64,
 }
 


### PR DESCRIPTION
## Summary

Adds three RPC methods from #5's "easy pickings" list, picking up where PR #8 left off:

- `get_account_info` / `get_account_info_with_commitment` — read arbitrary account data; returns `Option<AccountInfo>` (None for non-existent accounts).
- `get_multiple_accounts` / `get_multiple_accounts_with_commitment` — batch variant; the returned vector is parallel to `addresses` with `None` entries for missing accounts.
- `request_airdrop` — devnet/testnet/local-validator convenience that returns the airdrop tx signature. No commitment variant since the RPC doesn't accept one.

`AccountInfo` is the public struct exposed to callers. It carries the response shape listed verbatim in the issue: `data: Vec<u8>` (base64-decoded), `owner: Pubkey`, `lamports: u64`, `executable: bool`, `rent_epoch: u64`.

## Why this matters

Picking up the same checklist PR #8 started. The maintainer said "Feel free to tackle a subset rather than the whole list in one PR" so I'm sticking to a related cluster: the read-arbitrary-account methods plus the dev-UX airdrop helper. After this lands, 5 of 9 items are checked:

- [x] `getMinimumBalanceForRentExemption` — PR #8
- [x] `getSlot` / `getBlockHeight` — PR #8
- [x] `getAccountInfo` — this PR
- [x] `getMultipleAccounts` — this PR
- [x] `requestAirdrop` — this PR

Each method follows the existing `get_balance` / `get_slot` pattern: a no-commitment shortcut that delegates to a `_with_commitment` variant. The shared `RpcClient::call<T>` helper handles request / response plumbing exactly as the issue's "Implementation notes" section described.

## Changes

- `src/rpc.rs:1-12` — adds `std::str::FromStr`, `base64`, and `solana_pubkey::Pubkey` imports.
- `src/rpc.rs:211-298` — three new method pairs after `get_minimum_balance_for_rent_exemption`.
- `src/rpc.rs:300-339` — `AccountInfo` public struct, `AccountInfoRaw` private wire struct (with `#[serde(rename = "rentEpoch")]` so the camelCase RPC field actually maps), and `account_info_from_raw` helper that decodes base64 data and parses the owner pubkey.

## Testing

- `cargo check` — clean.
- `cargo build` — clean.
- `cargo build --target wasm32-unknown-unknown` — clean (this is a wasm-only crate).
- No existing methods touched; this is additive only, so existing demo apps keep working without changes.

Refs #5

This contribution was developed with AI assistance (Codex).
