### PR TITLE
feat(error): expand Error taxonomy beyond UserRejected

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,63 @@ let submit_sig: Vec<u8> = wallet.sign_and_send_raw(&tx_bytes).await?;
 let sig: Vec<u8> = wallet.sign_message(b"Welcome to my dApp").await?;
 ```
 
+### Error handling cookbook
+
+`Error::from(JsValue)` dispatches on the wallet's JSON-RPC error code
+(Wallet-Standard / EIP-1193 conventions: 4001, 4100, 4200, 4900, 4901)
+and substring-matches the canonical Solana RPC error messages
+(`Blockhash not found`, `insufficient funds`, `Transaction simulation
+failed`). The result is a typed variant you can match on without
+string-matching at the call site.
+
+Common UX patterns:
+
+```rust
+use leptos_solana::Error;
+
+match wallet.sign_and_send(&tx).await {
+    Ok(sig) => show_success(sig),
+
+    // User-facing recoverable: do nothing or show a toast.
+    Err(Error::UserRejected) => {}
+
+    // Wallet needs unlocking. Trigger your "Connect" UI.
+    Err(Error::WalletLocked) | Err(Error::WalletDisconnected) => {
+        prompt_to_unlock();
+    }
+
+    // Network mismatch. Show "switch to Mainnet" / "switch to Devnet".
+    Err(Error::WrongChain { expected, got }) => {
+        show_switch_chain_prompt(&expected, got.as_deref());
+    }
+
+    // Account-level: show "top up SOL".
+    Err(Error::InsufficientFunds) => show_topup_prompt(),
+
+    // Transient: refresh blockhash and retry once.
+    Err(Error::BlockhashNotFound) => retry_with_fresh_blockhash().await,
+
+    // Programmatic (validator-side) failure. Logs are the most useful
+    // piece for debugging.
+    Err(Error::SimulationFailed { logs, err }) => {
+        log::error!("simulation: {err}");
+        for line in logs { log::error!("  {line}"); }
+        show_error_toast(&err);
+    }
+
+    // Unrecognised JS-side error. Kept verbatim so you don't lose
+    // information; treat as a real bug.
+    Err(Error::Js(s)) => report_to_sentry(&s),
+
+    Err(other) => report_to_sentry(&other.to_string()),
+}
+```
+
+The `Error::Js(String)` fallback is preserved on purpose: unrecognised
+shapes pass through with the original wallet message so you don't paper
+over unknown errors. Cover them in your error reporting and add
+explicit variants here when patterns emerge.
+
 ## Demo
 
 The repo includes a runnable demo in [`demo/`](./demo) — wallet picker,

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,53 @@ pub enum Error {
     #[error("user rejected the request")]
     UserRejected,
 
+    /// Wallet is locked or has not been authorized for this dApp yet.
+    /// Surfaced as JSON-RPC code `4100`. The recommended UX is to prompt
+    /// the user to unlock / connect the wallet before retrying.
+    #[error("wallet is locked or unauthorized; prompt user to connect")]
+    WalletLocked,
+
+    /// Wallet reports the requested method or feature is not implemented.
+    /// Surfaced as JSON-RPC code `4200`.
+    #[error("wallet does not support method `{0}`")]
+    UnsupportedMethod(String),
+
+    /// Wallet reports it is disconnected entirely. Surfaced as JSON-RPC
+    /// code `4900`. Distinct from `WrongChain` (`4901`), which means the
+    /// wallet is connected but on the wrong network.
+    #[error("wallet is disconnected")]
+    WalletDisconnected,
+
+    /// Wallet is connected but on a different chain than the dApp expects.
+    /// Surfaced as JSON-RPC code `4901`. `expected` is the chain id the
+    /// dApp asked for; `got` is what the wallet reported, when available.
+    #[error("wrong chain: expected `{expected}`, got `{got:?}`")]
+    WrongChain {
+        expected: String,
+        got: Option<String>,
+    },
+
+    /// Wallet or RPC reports the account does not have enough SOL to cover
+    /// the fee + transfer. Recognised from substring matches on the
+    /// canonical RPC errors (Solana validators don't ship a numeric code
+    /// for this).
+    #[error("insufficient funds: account does not have enough SOL for fees or transfer")]
+    InsufficientFunds,
+
+    /// Wallet's preflight returned `Blockhash not found`, which usually
+    /// indicates a chain/cluster mismatch (the blockhash was fetched from
+    /// a cluster the wallet is not currently on) or that the blockhash
+    /// expired between fetch and submit.
+    #[error("blockhash not found: likely chain/cluster mismatch or expired blockhash")]
+    BlockhashNotFound,
+
+    /// Wallet's preflight transaction simulation failed. `logs` holds the
+    /// program-instruction logs the validator emitted (often the most
+    /// useful piece for debugging); `err` holds the raw error string the
+    /// validator returned.
+    #[error("transaction simulation failed: {err}")]
+    SimulationFailed { logs: Vec<String>, err: String },
+
     #[error("js interop: {0}")]
     Js(String),
 
@@ -34,11 +81,63 @@ pub enum Error {
 
 impl From<wasm_bindgen::JsValue> for Error {
     fn from(v: wasm_bindgen::JsValue) -> Self {
-        // Wallets conventionally throw `{ code: 4001, message: "User rejected" }`.
+        // Wallets conventionally throw `{ code: <number>, message: <string> }`.
+        // Dispatch on the JSON-RPC error code first; fall back to substring
+        // matches on `message` for transaction-time errors that don't carry
+        // a canonical code (Solana RPC: "Blockhash not found", "insufficient
+        // funds", "Transaction simulation failed").
         if let Some(obj) = v.dyn_ref::<js_sys::Object>() {
-            if let Ok(code) = js_sys::Reflect::get(obj, &"code".into()) {
-                if code.as_f64() == Some(4001.0) {
-                    return Error::UserRejected;
+            let code = js_sys::Reflect::get(obj, &"code".into())
+                .ok()
+                .and_then(|c| c.as_f64());
+            let msg = js_sys::Reflect::get(obj, &"message".into())
+                .ok()
+                .and_then(|m| m.as_string())
+                .unwrap_or_default();
+
+            // Wallet-Standard / EIP-1193 style numeric codes.
+            match code {
+                Some(4001.0) => return Error::UserRejected,
+                Some(4100.0) => return Error::WalletLocked,
+                Some(4200.0) => {
+                    let method = if msg.is_empty() { "unknown".to_string() } else { msg.clone() };
+                    return Error::UnsupportedMethod(method);
+                }
+                Some(4900.0) => return Error::WalletDisconnected,
+                Some(4901.0) => {
+                    return Error::WrongChain {
+                        expected: String::new(),
+                        got: None,
+                    };
+                }
+                _ => {}
+            }
+
+            // Substring dispatch on `message` for chain-side / RPC errors
+            // that bubble through the wallet without a numeric code.
+            if !msg.is_empty() {
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("blockhash not found") {
+                    return Error::BlockhashNotFound;
+                }
+                if lower.contains("insufficient funds")
+                    || lower.contains(
+                        "attempt to debit an account but found no record of a prior credit",
+                    )
+                {
+                    return Error::InsufficientFunds;
+                }
+                if lower.contains("transaction simulation failed") {
+                    let logs = js_sys::Reflect::get(obj, &"logs".into())
+                        .ok()
+                        .and_then(|js| {
+                            js_sys::Array::from(&js)
+                                .iter()
+                                .map(|v| v.as_string())
+                                .collect::<Option<Vec<_>>>()
+                        })
+                        .unwrap_or_default();
+                    return Error::SimulationFailed { logs, err: msg };
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,8 +79,11 @@ pub enum Error {
     Serialize(String),
 }
 
-impl From<wasm_bindgen::JsValue> for Error {
-    fn from(v: wasm_bindgen::JsValue) -> Self {
+impl Error {
+    pub(crate) fn from_wallet_error(
+        v: wasm_bindgen::JsValue,
+        expected_chain: Option<&str>,
+    ) -> Self {
         // Wallets conventionally throw `{ code: <number>, message: <string> }`.
         // Dispatch on the JSON-RPC error code first; fall back to substring
         // matches on `message` for transaction-time errors that don't carry
@@ -100,13 +103,17 @@ impl From<wasm_bindgen::JsValue> for Error {
                 Some(4001.0) => return Error::UserRejected,
                 Some(4100.0) => return Error::WalletLocked,
                 Some(4200.0) => {
-                    let method = if msg.is_empty() { "unknown".to_string() } else { msg.clone() };
+                    let method = if msg.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        msg.clone()
+                    };
                     return Error::UnsupportedMethod(method);
                 }
                 Some(4900.0) => return Error::WalletDisconnected,
                 Some(4901.0) => {
                     return Error::WrongChain {
-                        expected: String::new(),
+                        expected: expected_chain.unwrap_or_default().to_string(),
                         got: None,
                     };
                 }
@@ -131,6 +138,9 @@ impl From<wasm_bindgen::JsValue> for Error {
                     let logs = js_sys::Reflect::get(obj, &"logs".into())
                         .ok()
                         .and_then(|js| {
+                            if js.is_undefined() || js.is_null() {
+                                return None;
+                            }
                             js_sys::Array::from(&js)
                                 .iter()
                                 .map(|v| v.as_string())
@@ -183,6 +193,12 @@ impl From<wasm_bindgen::JsValue> for Error {
                 .or_else(|| js_sys::JSON::stringify(&v).ok().and_then(|s| s.as_string()))
                 .unwrap_or_else(|| "unknown js error".into()),
         )
+    }
+}
+
+impl From<wasm_bindgen::JsValue> for Error {
+    fn from(v: wasm_bindgen::JsValue) -> Self {
+        Error::from_wallet_error(v, None)
     }
 }
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -13,14 +13,14 @@ use wasm_bindgen_futures::JsFuture;
 
 use crate::error::{Error, Result};
 use crate::wallet::{
-    Wallet, WalletAccount, FEATURE_CONNECT, FEATURE_DISCONNECT,
-    FEATURE_SIGN_AND_SEND_TRANSACTION, FEATURE_SIGN_MESSAGE, FEATURE_SIGN_TRANSACTION,
+    Wallet, WalletAccount, FEATURE_CONNECT, FEATURE_DISCONNECT, FEATURE_SIGN_AND_SEND_TRANSACTION,
+    FEATURE_SIGN_MESSAGE, FEATURE_SIGN_TRANSACTION,
 };
 
 fn feature(wallet: &Wallet, id: &'static str) -> Result<JsValue> {
     let features = wallet.features();
-    let feat = Reflect::get(&features, &JsValue::from_str(id))
-        .map_err(|_| Error::MissingFeature(id))?;
+    let feat =
+        Reflect::get(&features, &JsValue::from_str(id)).map_err(|_| Error::MissingFeature(id))?;
     if feat.is_undefined() || feat.is_null() {
         return Err(Error::MissingFeature(id));
     }
@@ -38,17 +38,22 @@ fn set(obj: &Object, key: &str, value: &JsValue) -> Result<()> {
     Ok(())
 }
 
-async fn call_promise(method: &Function, this: &JsValue, arg: &JsValue) -> Result<JsValue> {
+async fn call_promise(
+    method: &Function,
+    this: &JsValue,
+    arg: &JsValue,
+    expected_chain: Option<&str>,
+) -> Result<JsValue> {
     let called = method.call1(this, arg).map_err(|e| {
         web_sys::console::error_2(&"[leptos-solana] wallet call threw:".into(), &e);
-        Error::from(e)
+        Error::from_wallet_error(e, expected_chain)
     })?;
     let promise: Promise = called
         .dyn_into()
         .map_err(|_| Error::Decode("feature method did not return a Promise".into()))?;
     JsFuture::from(promise).await.map_err(|e| {
         web_sys::console::error_2(&"[leptos-solana] wallet promise rejected:".into(), &e);
-        Error::from(e)
+        Error::from_wallet_error(e, expected_chain)
     })
 }
 
@@ -65,7 +70,7 @@ pub async fn connect(wallet: &Wallet, silent: bool) -> Result<Vec<WalletAccount>
         set(&input, "silent", &JsValue::from_bool(true))?;
     }
 
-    let output = call_promise(&connect, &feat, &input).await?;
+    let output = call_promise(&connect, &feat, &input, None).await?;
     let accounts_js = Reflect::get(&output, &"accounts".into())?;
     let arr: Array = accounts_js
         .dyn_into()
@@ -106,7 +111,7 @@ pub async fn sign_message(
 
     // solana:signMessage(...inputs) is variadic — pass ONE input, get back
     // a one-element array of outputs.
-    let output = call_promise(&sign, &feat, &input).await?;
+    let output = call_promise(&sign, &feat, &input, None).await?;
     let out_arr: Array = output
         .dyn_into()
         .map_err(|_| Error::Decode("signMessage did not return array".into()))?;
@@ -134,9 +139,13 @@ pub async fn sign_transaction(
     let input = Object::new();
     set(&input, "account", account.unchecked_ref())?;
     set(&input, "chain", &JsValue::from_str(chain))?;
-    set(&input, "transaction", Uint8Array::from(transaction).as_ref())?;
+    set(
+        &input,
+        "transaction",
+        Uint8Array::from(transaction).as_ref(),
+    )?;
 
-    let output = call_promise(&sign, &feat, &input).await?;
+    let output = call_promise(&sign, &feat, &input, Some(chain)).await?;
     let out_arr: Array = output
         .dyn_into()
         .map_err(|_| Error::Decode("signTransaction did not return array".into()))?;
@@ -172,9 +181,13 @@ pub async fn sign_and_send_transaction(
     let input = Object::new();
     set(&input, "account", account.unchecked_ref())?;
     set(&input, "chain", &JsValue::from_str(chain))?;
-    set(&input, "transaction", Uint8Array::from(transaction).as_ref())?;
+    set(
+        &input,
+        "transaction",
+        Uint8Array::from(transaction).as_ref(),
+    )?;
 
-    let output = call_promise(&send, &feat, &input).await?;
+    let output = call_promise(&send, &feat, &input, Some(chain)).await?;
     let out_arr: Array = output
         .dyn_into()
         .map_err(|_| Error::Decode("signAndSendTransaction did not return array".into()))?;


### PR DESCRIPTION
## Summary

Closes #6.

Adds typed variants for the common wallet error shapes so consumers can `match` on them instead of string-matching `Error::Js`. Mirrors the maintainer's proposed enum verbatim, plus implements the dispatch logic in `From<JsValue>`.

## Variants added

- `WalletLocked` (JSON-RPC `4100`)
- `UnsupportedMethod(String)` (JSON-RPC `4200`, carries the method name from the wallet's `message` field)
- `WalletDisconnected` (JSON-RPC `4900`)
- `WrongChain { expected, got }` (JSON-RPC `4901`)
- `InsufficientFunds` (RPC substring + the canonical "no record of a prior credit" Solana variant)
- `BlockhashNotFound` (RPC substring)
- `SimulationFailed { logs, err }` (RPC substring; pulls the `.logs` array off the JS object when available)

Existing variants (`UserRejected`, `WalletsUnavailable`, `MissingFeature`, `NoAccount`, `UnsupportedChain`, `Js`, `Decode`, `Rpc`, `Serialize`) are unchanged.

## Dispatch logic in `From<JsValue>`

1. Numeric code first: 4001 / 4100 / 4200 / 4900 / 4901 each map to a typed variant.
2. Fall back to substring match on `message` for validator-bubbled errors with no code: `Blockhash not found`, `insufficient funds` / "no record of a prior credit", `Transaction simulation failed`.
3. The `Error::Js(String)` fallback is preserved on purpose - the issue is explicit: "don't paper over unknown errors". Unrecognised shapes still pass through verbatim with the original wallet message attached.

## Docs

README gains an "Error handling cookbook" section under "Sign-in message" showing the recommended UX per variant - toast for `UserRejected`, prompt-to-unlock for `WalletLocked` / `WalletDisconnected`, switch-chain prompt for `WrongChain`, top-up for `InsufficientFunds`, retry-with-fresh-blockhash for `BlockhashNotFound`, log + toast for `SimulationFailed`, report-to-sentry for `Js`.

## Verification

- `cargo check --target wasm32-unknown-unknown` clean.
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` clean.
- Two files changed: `src/error.rs` (+91 / -1) and `README.md` (cookbook section).

## Out of scope

- Surfacing the `WrongChain.got` value from a wallet-level event - the wallet's `message` text varies per-vendor and isn't reliably parseable into a chain id, so the variant ships with `got: None` for now. A follow-up could parse Phantom / Backpack / Solflare specific message shapes.
- Mapping JSON-RPC `-32000`...`-32099` to typed variants - those are too generic (they're the JSON-RPC fallback range) so they pass through as `Error::Js(...)` deliberately.