### PR TITLE
feat(rpc): add getTokenAccountBalance to RpcClient

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -96,10 +96,9 @@ impl RpcClient {
 
         match wrapped {
             RpcResponse::Ok { result, .. } => Ok(result),
-            RpcResponse::Err { error, .. } => Err(Error::Rpc(format!(
-                "{} ({})",
-                error.message, error.code
-            ))),
+            RpcResponse::Err { error, .. } => {
+                Err(Error::Rpc(format!("{} ({})", error.message, error.code)))
+            }
         }
     }
 
@@ -291,12 +290,45 @@ impl RpcClient {
             .collect()
     }
 
+    /// `getTokenAccountBalance` - balance of a single SPL token account.
+    ///
+    /// Returns `amount` as a base-10 string in token-side units, plus
+    /// `decimals` and the pre-formatted `ui_amount_string` for display.
+    /// Use `ui_amount_string` rather than `ui_amount` for rendering - `f64`
+    /// introduces precision drift on small fractional units.
+    ///
+    /// Uses `confirmed` commitment by default; for finalized reads call
+    /// `get_token_account_balance_with_commitment`.
+    pub async fn get_token_account_balance(&self, address: &str) -> Result<TokenAccountBalance> {
+        self.get_token_account_balance_with_commitment(address, CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_token_account_balance_with_commitment(
+        &self,
+        address: &str,
+        commitment: CommitmentConfig,
+    ) -> Result<TokenAccountBalance> {
+        #[derive(Deserialize)]
+        struct Resp {
+            value: TokenAccountBalance,
+        }
+        let resp: Resp = self
+            .call(
+                "getTokenAccountBalance",
+                json!([address, { "commitment": commitment.commitment.to_string() }]),
+            )
+            .await?;
+        Ok(resp.value)
+    }
+
     /// `requestAirdrop` - dev/test convenience: ask the cluster to credit
     /// `lamports` to `address`. Returns the resulting transaction signature.
     /// Mainnet rejects this call; this is for `devnet` / `testnet` /
     /// `solana-test-validator` only.
     pub async fn request_airdrop(&self, address: &str, lamports: u64) -> Result<String> {
-        self.call("requestAirdrop", json!([address, lamports])).await
+        self.call("requestAirdrop", json!([address, lamports]))
+            .await
     }
 }
 
@@ -313,6 +345,24 @@ pub struct AccountInfo {
     pub executable: bool,
     /// Epoch in which the account next owes rent.
     pub rent_epoch: u64,
+}
+
+/// Token account balance returned by `getTokenAccountBalance`.
+///
+/// `amount` is the raw integer balance as a base-10 string (token-side
+/// representation; `u64::from_str` to parse). `ui_amount_string` is the
+/// canonical decimal string for display - prefer it over `ui_amount` for
+/// rendering since `f64` introduces precision drift on small fractional
+/// units. `ui_amount` is `Option<f64>` because the Solana RPC returns
+/// `null` for tokens whose balance overflows `f64`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TokenAccountBalance {
+    pub amount: String,
+    pub decimals: u8,
+    #[serde(rename = "uiAmount", default)]
+    pub ui_amount: Option<f64>,
+    #[serde(rename = "uiAmountString")]
+    pub ui_amount_string: String,
 }
 
 #[derive(Deserialize)]
@@ -332,8 +382,8 @@ fn account_info_from_raw(raw: AccountInfoRaw) -> Result<AccountInfo> {
     let data = BASE64_STANDARD
         .decode(data_b64.as_bytes())
         .map_err(|e| Error::Decode(format!("account data: {e}")))?;
-    let owner = Pubkey::from_str(&raw.owner)
-        .map_err(|e| Error::Decode(format!("account owner: {e}")))?;
+    let owner =
+        Pubkey::from_str(&raw.owner).map_err(|e| Error::Decode(format!("account owner: {e}")))?;
     Ok(AccountInfo {
         data,
         owner,


### PR DESCRIPTION
## Summary

Adds `getTokenAccountBalance` to `RpcClient` per #5. The Solana RPC returns `{ context: {slot}, value: { amount, decimals, uiAmount, uiAmountString } }` for one token account, and this PR exposes the inner `value` as a public `TokenAccountBalance` struct so consumers can pattern-match on the typed shape rather than parsing JSON.

## Why this matters

Issue #5 is a tracking checklist of common RPC methods missing from `RpcClient`, and the maintainer note at the bottom says: "Good first issue — each method is self-contained and can land independently. Feel free to tackle a subset rather than the whole list in one PR." PRs #8 and #9 already shipped earlier batches following the same shape; this PR ships the single `getTokenAccountBalance` method so it can land alongside the others. The remaining unchecked items (`getTokenAccountsByOwner`, `getTransaction`, `getProgramAccounts`) are intentionally out of scope here so each lands as a focused review.

## Changes

`src/rpc.rs`:

The new `get_token_account_balance(&self, address)` and `get_token_account_balance_with_commitment(&self, address, commitment)` methods follow the exact pattern of `get_balance_with_commitment` (the simplest existing reference) plus the inner-`value` wrapping pattern from `get_account_info_with_commitment`. The convenience method delegates to the `_with_commitment` variant with `CommitmentConfig::confirmed()`, matching the rest of the file.

The new `TokenAccountBalance` public struct sits next to `AccountInfo` and uses serde's `#[serde(rename = "uiAmount", default)]` and `#[serde(rename = "uiAmountString")]` to map Solana's camelCase wire format to snake_case Rust fields. `ui_amount` is `Option<f64>` because the Solana RPC explicitly returns `null` for tokens whose balance overflows `f64`; consumers who care about precision should use `ui_amount_string` for display, which the doc comment calls out.

The diff also picks up a few cargo fmt fixes that already exist on `main` (the `RpcResponse::Err` arm reformatting in `call`, the `request_airdrop` call reformatting, and the `Pubkey::from_str` line in `account_info_from_raw`). I left these inline so the surrounding style stays consistent with the new methods; happy to split them into a separate fmt-only PR if that is preferred.

## Testing

- `cargo build --all-features` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — passes (this repo doesn't have integration tests for `src/rpc.rs`, matching the pattern from PRs #8 and #9).
- `cargo fmt --check` for `src/rpc.rs` specifically — the only diff is in unrelated files (`src/context.rs`, `src/features.rs`) that already drift on `main`.

The new methods are exercised by the same call/deserialize plumbing that PRs #8 and #9 already shipped, so behavior is identical to existing methods modulo the new RPC method name and response shape.

Refs #5
