### PR TITLE
feat(rpc): add getTransaction to RpcClient

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -322,6 +322,38 @@ impl RpcClient {
         Ok(resp.value)
     }
 
+    /// `getTransaction` - fetch a landed transaction with execution logs.
+    /// Returns `None` if the signature is unknown or has not yet landed.
+    ///
+    /// Useful for debugging: log messages, fee, and a top-level err for
+    /// failed transactions are all included on the returned struct.
+    ///
+    /// Uses `confirmed` commitment by default; for finalized reads call
+    /// `get_transaction_with_commitment`.
+    pub async fn get_transaction(&self, signature: &str) -> Result<Option<TransactionStatus>> {
+        self.get_transaction_with_commitment(signature, CommitmentConfig::confirmed())
+            .await
+    }
+
+    pub async fn get_transaction_with_commitment(
+        &self,
+        signature: &str,
+        commitment: CommitmentConfig,
+    ) -> Result<Option<TransactionStatus>> {
+        self.call(
+            "getTransaction",
+            json!([
+                signature,
+                {
+                    "commitment": commitment.commitment.to_string(),
+                    "encoding": "json",
+                    "maxSupportedTransactionVersion": 0,
+                }
+            ]),
+        )
+        .await
+    }
+
     /// `requestAirdrop` - dev/test convenience: ask the cluster to credit
     /// `lamports` to `address`. Returns the resulting transaction signature.
     /// Mainnet rejects this call; this is for `devnet` / `testnet` /
@@ -363,6 +395,32 @@ pub struct TokenAccountBalance {
     pub ui_amount: Option<f64>,
     #[serde(rename = "uiAmountString")]
     pub ui_amount_string: String,
+}
+
+/// Subset of `getTransaction` response useful for debugging - slot,
+/// timing, fee, log messages, and a top-level error if execution failed.
+/// The full `transaction` and `inner_instructions` are intentionally
+/// omitted to keep this struct small; if you need them, query the RPC
+/// directly via `call`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TransactionStatus {
+    pub slot: u64,
+    #[serde(rename = "blockTime", default)]
+    pub block_time: Option<i64>,
+    #[serde(default)]
+    pub meta: Option<TransactionMeta>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TransactionMeta {
+    /// `None` on success, `Some(serde_json::Value)` describing the
+    /// failure on error. Solana's err shape varies (InstructionError,
+    /// InsufficientFundsForRent, etc.), so we surface raw JSON.
+    #[serde(default)]
+    pub err: Option<serde_json::Value>,
+    pub fee: u64,
+    #[serde(rename = "logMessages", default)]
+    pub log_messages: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Adds `get_transaction` and `get_transaction_with_commitment` to `RpcClient`, plus public `TransactionStatus` and `TransactionMeta` structs that surface the slot, block time, fee, top-level err, and log messages — the slice you need to debug a landed transaction.

The result is `Option<TransactionStatus>` because Solana returns `null` for signatures that are unknown or have not yet landed; serde produces `None` straight from JSON-null. The full `transaction` body and `inner_instructions` are intentionally omitted to keep `TransactionStatus` small; consumers who need them can drop down to `RpcClient::call`.

`log_messages` is `Option<Vec<String>>` because Solana's RPC may return `meta.logMessages: null` for transactions without recorded logs.

## What changed

`src/rpc.rs`:
- New methods `get_transaction(sig)` (default `confirmed` commitment) and `get_transaction_with_commitment(sig, c)` mirroring the existing `get_balance` / `get_account_info` pattern
- New public structs `TransactionStatus { slot, block_time, meta }` and `TransactionMeta { err, fee, log_messages }` placed next to `TokenAccountBalance`

58 lines added, 0 removed.

## Verification

- `cargo build` — pass
- `cargo build --target wasm32-unknown-unknown` — pass
- `cargo fmt -- src/rpc.rs --check` — pass

Refs #5

This addresses the unchecked `getTransaction — fetch a landed tx with logs for debugging` checkbox. Per the issue body ("each method is self-contained and can land independently"), the remaining items (`getTokenAccountsByOwner`, `getProgramAccounts`) are intentionally out of scope here.

This contribution was developed with AI assistance.